### PR TITLE
출석부 개근 일수가 올라가지 않는 문제점 개선. By 위드마스터

### DIFF
--- a/queries/insertTotal.xml
+++ b/queries/insertTotal.xml
@@ -5,9 +5,9 @@
     <columns>
         <column name="regdate" default="curdate()" var="regdate" notnull="notnull" />
         <column name="member_srl" var="member_srl" default="admin" />
-	    <column name="total" var="total" />
-	    <column name="total_point" var="total_point" />
-	    <column name="continuity" var="continuity" />
-	    <column name="continuity_point" var="continuity_point" />
+	    <column name="total" var="total"  default="0" />
+	    <column name="total_point" var="total_point"  default="0" />
+	    <column name="continuity" var="continuity"  default="0" />
+	    <column name="continuity_point" var="continuity_point" default="0" />
     </columns>
 </query>


### PR DESCRIPTION
Attendance_total 의 DB구조가 다음과 같이 이루어져 있습니다.

``` xml
<table name="attendance_total">
    <column name="regdate" type="varchar" size="14" notnull="notnull"  />
    <column name="member_srl" type="number" size="11" notnull="notnull"  />
    <column name="total" type="number" size="11" notnull="notnull" />
    <column name="total_point" type="number" size="20" notnull="notnull" />
    <column name="continuity" type="number" size="11" notnull="notnull" />
    <column name="continuity_point" type="number" size="20" notnull="notnull" />
</table>

```

`notnull="notnull"` 의옵션으로 인해서, 0의 값과 동일하게 DB가 `NULL` 디비가 들어갈경우 전체가 디비를 넣지 못하면서 생기는 문제점입니다.

보통 `continuity_point`의 값을 지정하지 않고 `NULL`값으로 들어가서 인설트하는 과정에서 생긴 문제점으로 이를 해결하기 위해서는 쿼리에서 Total에 디폴트값중에 0이라도 줘야합니다.

나머지는 코드를 참고해주세요. 
